### PR TITLE
Feature/registration partner id updates

### DIFF
--- a/api/services/registration_service.py
+++ b/api/services/registration_service.py
@@ -32,7 +32,7 @@ class RegistrationService:
             user_phone=data["from_number"],
             system_phone=url_decoded_system_phone,
             status="pending",
-            partner_id=partner.id,
+            partner_id=partner.partner_id,
             state=system_phone.state,
             has_dropped_missedcall=True,
         )


### PR DESCRIPTION
Hot fixing the referential integrity error occurring due to the use of `id` instead of `partner_id` of the `partner_system_phone` while creating a registration.