### PR TITLE
Add "Picktime" only when available otherwise it should be null.

### DIFF
--- a/api/services/handle_event_service.py
+++ b/api/services/handle_event_service.py
@@ -56,10 +56,10 @@ class HandleEventService:
                 The telco code for answered calls is 16.
                 """
                 if form_data["TelcoCode"] == str(app.config["TELCO_CODE_ANSWERED"]):
-                    if form_data["PickTime"]:
-                        data["pick_time"] = form_data["PickTime"]
-                    else:
+                    if form_data.get("PickTime", None):
                         data["pick_time"] = None
+                    else:
+                        data["pick_time"] = form_data["PickTime"]
 
             call_log_event.CallLogEventService.create_call_log_event(self, data)
             if data["call_status"] == "Missed":

--- a/api/services/handle_event_service.py
+++ b/api/services/handle_event_service.py
@@ -56,8 +56,7 @@ class HandleEventService:
                 The telco code for answered calls is 16.
                 """
                 if form_data["TelcoCode"] == str(app.config["TELCO_CODE_ANSWERED"]):
-                    if form_data.get("PickTime", None):
-                        data["pick_time"] = form_data["PickTime"]
+                    data["pick_time"] = form_data.get("PickTime")
 
             call_log_event.CallLogEventService.create_call_log_event(self, data)
             if data["call_status"] == "Missed":

--- a/api/services/handle_event_service.py
+++ b/api/services/handle_event_service.py
@@ -57,8 +57,6 @@ class HandleEventService:
                 """
                 if form_data["TelcoCode"] == str(app.config["TELCO_CODE_ANSWERED"]):
                     if form_data.get("PickTime", None):
-                        data["pick_time"] = None
-                    else:
                         data["pick_time"] = form_data["PickTime"]
 
             call_log_event.CallLogEventService.create_call_log_event(self, data)

--- a/api/services/handle_event_service.py
+++ b/api/services/handle_event_service.py
@@ -56,7 +56,10 @@ class HandleEventService:
                 The telco code for answered calls is 16.
                 """
                 if form_data["TelcoCode"] == str(app.config["TELCO_CODE_ANSWERED"]):
-                    data["pick_time"] = form_data["PickTime"]
+                    if form_data["PickTime"]:
+                        data["pick_time"] = form_data["PickTime"]
+                    else:
+                        data["pick_time"] = None
 
             call_log_event.CallLogEventService.create_call_log_event(self, data)
             if data["call_status"] == "Missed":


### PR DESCRIPTION
#52 
<!--- If there is an open issue, please link to the issue here by replacing [ISSUE_ID]-->
<!-- Make sure the PR is against the `develop` branch -->

### Please complete the following steps and check these boxes before filing your PR:


### Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (a change which fixes an issue)
- [ ] New feature (a change which adds functionality)


### Short description of what this resolves:
Describe your changes in detail 
- The error log was generated when the call is received by the user and disconnected. The duration of the call between the start and end is 0. Therefore, we are not getting any PickTime for that call_log.
- Now in this PR change we have added a null value to the PickTime column when we are not getting it in the call_log data.


<!--- Why these change required? What problem does it solve? -->


### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
- [x] The code follows the style guidelines of this project.
- [x] The code changes are passing the CI checks
- [ ] I have documented my code wherever required.
- [ ] The changes requires a change to the documentation.
- [ ] I have updated the documentation based on the my changes.
<!--- TODO: need to uncomment these two checklist once we start with test cases.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.
-->
